### PR TITLE
fix: enable gateway deployment in kind submodule

### DIFF
--- a/kind/main.tf
+++ b/kind/main.tf
@@ -15,6 +15,7 @@ module "istio" {
   target_revision        = var.target_revision
   enable_service_monitor = var.enable_service_monitor
   app_autosync           = var.app_autosync
+  gateway                = true
 
   helm_values = concat(local.helm_values, var.helm_values)
 


### PR DESCRIPTION
## Changes

- Add `gateway = true` in `kind/main.tf` when calling the parent istio module.

## Problem

The `kind` submodule expects the `istio-gateway-istio` LoadBalancer service to exist (it reads it via `data.kubernetes_service.istio_gateway`), but `argocd_application.gateway` has `count = var.gateway ? 1 : 0` and `var.gateway` defaults to `false`. Without passing `gateway = true`, the gateway ArgoCD application was never created, causing `null_resource.wait_for_gateway_service` to loop indefinitely.

## Fix

Hardcode `gateway = true` in `kind/main.tf` since the kind submodule always requires the gateway service to derive the external IP.