### PR TITLE
fix: replace old Istio Gateway with Kubernetes Gateway API resource

### DIFF
--- a/charts/gateway/templates/gateway.yaml
+++ b/charts/gateway/templates/gateway.yaml
@@ -1,17 +1,26 @@
-apiVersion: networking.istio.io/v1alpha3
+{{- $gateway_config := .Values.gateway_config | default dict }}
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: istio-ingressgateway
-  labels:
-    release: istio
+  name: {{ $gateway_config.name | default "istio-gateway" }}
+  namespace: {{ .Release.Namespace }}
 spec:
-  selector:
-    app: istio-ingressgateway
-    istio: ingressgateway
-  servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
-    - '*'
+  gatewayClassName: istio
+  listeners:
+  - protocol: HTTP
+    port: 80
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+  - protocol: HTTPS
+    port: 443
+    name: https
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: istio-gateway-tls
+        kind: Secret
+    allowedRoutes:
+      namespaces:
+        from: All

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -15,6 +15,7 @@ module "istio" {
   target_revision        = var.target_revision
   enable_service_monitor = var.enable_service_monitor
   app_autosync           = var.app_autosync
+  gateway                = true
 
   helm_values = concat(local.helm_values, var.helm_values)
 


### PR DESCRIPTION
## Changes

Replace the old `networking.istio.io/v1alpha3/Gateway` template with a Kubernetes Gateway API `gateway.networking.k8s.io/v1/Gateway` resource.

## Problem

The `wait_for_gateway_service` provisioner waits for the service `istio-gateway-istio` which is **only created by Istiod** when it sees a `gateway.networking.k8s.io/v1/Gateway` resource with `gatewayClassName: istio`. The old template used the deprecated Istio API (`networking.istio.io/v1alpha3`) which does NOT trigger automatic service provisioning.

## Fix

The new template deploys a Kubernetes Gateway API `Gateway` resource. When Istiod sees this, it automatically provisions:
- A gateway Deployment
- A LoadBalancer Service named `istio-gateway-istio`

MetalLB then assigns an external IP to this service, which unblocks `wait_for_gateway_service` and allows HTTPRoute resources to work.