### PR TITLE
feat: replace local-exec crd/cert with declarative argocd app and kubernetes manifest

### DIFF
--- a/kind/local.tf
+++ b/kind/local.tf
@@ -3,6 +3,7 @@ locals {
     istiod = {}
   }]
 
-  gateway_domain  = var.base_domain != "" ? "${var.subdomain != "" ? "${trimprefix(var.subdomain, ".")}." : ""}${var.base_domain}" : "${var.subdomain != "" ? trimprefix(var.subdomain, ".") : "apps"}.nip.io"
+  gateway_ip      = try(data.kubernetes_service.istio_gateway.status[0].load_balancer[0].ingress[0].ip, "127.0.0.1")
+  gateway_domain  = var.base_domain != "" ? "${var.subdomain != "" ? "${trimprefix(var.subdomain, ".")}." : ""}${var.base_domain}" : format("%s.nip.io", replace(local.gateway_ip, ".", "-"))
   kubectl_context = var.kubectl_context != "" ? var.kubectl_context : "kind-${var.cluster_name}"
 }

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -28,40 +28,29 @@ data "kubernetes_service" "istio_gateway" {
     name      = replace(format("istio-gateway-istio%s", module.istio.id), module.istio.id, "")
     namespace = "istio-ingress"
   }
-}
-
-resource "null_resource" "istio_gateway_certificate" {
-  triggers = {
-    cluster_issuer = var.cluster_issuer
-    domain         = local.gateway_domain
-  }
-
-  provisioner "local-exec" {
-    environment = {
-      KUBE_CONTEXT = local.kubectl_context
-    }
-    command = <<-EOT
-until kubectl --context=$KUBE_CONTEXT get clusterissuer '${var.cluster_issuer}' 2>/dev/null; do
-  echo "Aguardando ClusterIssuer ${var.cluster_issuer}..."
-  sleep 5
-done
-kubectl --context=$KUBE_CONTEXT apply -f - <<'CERT'
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: istio-gateway-tls
-  namespace: istio-ingress
-spec:
-  secretName: istio-gateway-tls
-  issuerRef:
-    name: ${var.cluster_issuer}
-    kind: ClusterIssuer
-  dnsNames:
-    - "*.${local.gateway_domain}"
-CERT
-kubectl --context=$KUBE_CONTEXT wait --for=condition=Ready certificate/istio-gateway-tls -n istio-ingress --timeout=120s
-EOT
-  }
 
   depends_on = [module.istio]
+}
+
+resource "kubernetes_manifest" "istio_gateway_certificate" {
+  manifest = {
+    apiVersion = "cert-manager.io/v1"
+    kind       = "Certificate"
+    metadata = {
+      name      = "istio-gateway-tls"
+      namespace = "istio-ingress"
+    }
+    spec = {
+      secretName = "istio-gateway-tls"
+      issuerRef = {
+        name = var.cluster_issuer
+        kind = "ClusterIssuer"
+      }
+      dnsNames = [
+        "*.${local.gateway_domain}"
+      ]
+    }
+  }
+
+  depends_on = [data.kubernetes_service.istio_gateway]
 }

--- a/kind/outputs.tf
+++ b/kind/outputs.tf
@@ -6,7 +6,7 @@ output "id" {
 output "external_ip" {
   description = "External IP address of the Istio ingress gateway LoadBalancer service."
   value       = try(data.kubernetes_service.istio_gateway.status.0.load_balancer.0.ingress.0.ip, "127.0.0.1")
-  depends_on  = [null_resource.istio_gateway_certificate]
+  depends_on  = [kubernetes_manifest.istio_gateway_certificate]
 }
 
 output "gateway_name" {

--- a/main.tf
+++ b/main.tf
@@ -38,31 +38,64 @@ resource "argocd_project" "this" {
   }
 }
 
-resource "null_resource" "check_crd" {
-  depends_on = [resource.null_resource.dependencies]
-
-  triggers = {
-    gateway_api_crds_version = "v1.4.0"
+resource "argocd_application" "gateway_api_crds" {
+  metadata {
+    name      = var.destination_cluster != "in-cluster" ? "gateway-api-crds-${var.destination_cluster}" : "gateway-api-crds"
+    namespace = var.argocd_namespace
+    labels = merge({
+      "application" = "gateway-api-crds"
+      "cluster"     = var.destination_cluster
+    }, var.argocd_labels)
   }
 
-  provisioner "local-exec" {
-    environment = {
-      KUBE_CONTEXT = var.kubectl_context
+  timeouts {
+    create = "15m"
+    delete = "15m"
+  }
+
+  wait = var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? false : true
+
+  spec {
+    project = var.argocd_project == null ? argocd_project.this[0].metadata.0.name : var.argocd_project
+
+    source {
+      repo_url        = "https://github.com/kubernetes-sigs/gateway-api"
+      path            = "config/crd"
+      target_revision = "v1.4.0"
     }
-    command = <<EOT
-      KUBECTL_ARGS="$${KUBE_CONTEXT:+--context=$KUBE_CONTEXT}"
-      if kubectl $KUBECTL_ARGS get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; then
-        echo "CRD já instalado."
-      else
-        echo "CRD não encontrado. Instalando..."
-        kubectl $KUBECTL_ARGS kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.4.0" | kubectl $KUBECTL_ARGS apply -f -
-      fi
 
-      kubectl $KUBECTL_ARGS wait --for=condition=Established --timeout=120s crd/gatewayclasses.gateway.networking.k8s.io
-      kubectl $KUBECTL_ARGS wait --for=condition=Established --timeout=120s crd/gateways.gateway.networking.k8s.io
-      kubectl $KUBECTL_ARGS wait --for=condition=Established --timeout=120s crd/httproutes.gateway.networking.k8s.io
-    EOT
+    destination {
+      name      = var.destination_cluster
+      namespace = var.namespace
+    }
+
+    sync_policy {
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
+      }
+
+      retry {
+        backoff {
+          duration     = "20s"
+          max_duration = "2m"
+          factor       = "2"
+        }
+        limit = "5"
+      }
+
+      sync_options = [
+        "CreateNamespace=true",
+        "Replace=true",
+      ]
+    }
   }
+
+  depends_on = [null_resource.dependencies]
 }
 
 resource "argocd_application" "base" {
@@ -130,7 +163,7 @@ resource "argocd_application" "base" {
       ]
     }
   }
-  depends_on = [null_resource.check_crd]
+  depends_on = [argocd_application.gateway_api_crds]
 }
 
 resource "argocd_application" "istiod" {


### PR DESCRIPTION
## Summary

- Replace `null_resource.check_crd` (local-exec kubectl) with `argocd_application.gateway_api_crds` using native ArgoCD Kustomize source
- Replace `null_resource.istio_gateway_certificate` (local-exec kubectl) with `kubernetes_manifest` Certificate resource
- Certificate domain auto-derived from gateway LB IP when `base_domain` is not provided

## Why
- Removes shell/kubectl dependencies from module execution
- All infrastructure now managed declaratively through ArgoCD and Terraform providers
- Full integration with cert-manager: Certificate object is reconciled by the cert-manager operator via ClusterIssuer