### PR TITLE
fix: break istio gateway tls bootstrap deadlock

### DIFF
--- a/kind/local.tf
+++ b/kind/local.tf
@@ -3,6 +3,11 @@ locals {
     istiod = {}
   }]
 
-  gateway_ip     = resource.kubernetes_manifest.wait_for_istio_gateway.object.status[0].loadBalancer[0].ingress[0].ip
-  gateway_domain = format("%s.nip.io", replace(local.gateway_ip, ".", "-"))
+  gateway_ip = data.kubernetes_resource.istio_gateway.object.status.loadBalancer.ingress[0].ip
+
+  # Base domain: uses the provided base_domain, otherwise derives a nip.io domain from the gateway LoadBalancer IP.
+  gateway_base = var.base_domain != "" ? var.base_domain : format("%s.nip.io", replace(local.gateway_ip, ".", "-"))
+
+  # Full domain used by the services' HTTPRoutes, e.g. "apps.172-18-0-100.nip.io".
+  gateway_domain = var.subdomain != "" ? "${trimprefix(var.subdomain, ".")}.${local.gateway_base}" : local.gateway_base
 }

--- a/kind/local.tf
+++ b/kind/local.tf
@@ -3,6 +3,6 @@ locals {
     istiod = {}
   }]
 
-  gateway_ip     = resource.kubernetes_manifest.wait_for_istio_gateway.object.status.loadBalancer.ingress[0].ip
+  gateway_ip     = resource.kubernetes_manifest.wait_for_istio_gateway.object.status[0].loadBalancer[0].ingress[0].ip
   gateway_domain = format("%s.nip.io", replace(local.gateway_ip, ".", "-"))
 }

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -23,29 +23,20 @@ module "istio" {
   dependency_ids = var.dependency_ids
 }
 
-resource "kubernetes_manifest" "wait_for_istio_gateway" {
+# Reads the Istio ingress gateway Service (created by ArgoCD when the gateway
+# Application syncs) to obtain its LoadBalancer IP. The IP is used to derive the
+# nip.io domain for the gateway TLS certificate. `depends_on` defers the read to
+# apply time, after the module has created the gateway Application.
+data "kubernetes_resource" "istio_gateway" {
+  api_version = "v1"
+  kind        = "Service"
+
+  metadata {
+    name      = "istio-gateway-istio"
+    namespace = "istio-ingress"
+  }
+
   depends_on = [module.istio]
-
-  manifest = {
-    apiVersion = "v1"
-    kind       = "Service"
-    metadata = {
-      name      = "istio-gateway-istio"
-      namespace = "istio-ingress"
-    }
-  }
-
-  # Força o Terraform a apenas ler o recurso existente e esperar, sem tentar recriá-lo
-  field_manager {
-    force_conflicts = true
-  }
-
-  # Aguarda até que o campo do LoadBalancer seja preenchido com o IP
-  wait {
-    fields = {
-      "status.loadBalancer.ingress" = "*"
-    }
-  }
 }
 
 resource "kubernetes_manifest" "istio_gateway_certificate" {
@@ -63,10 +54,11 @@ resource "kubernetes_manifest" "istio_gateway_certificate" {
         kind = "ClusterIssuer"
       }
       dnsNames = [
-        "*.${local.gateway_domain}"
+        "*.${local.gateway_domain}",
+        "*.${local.gateway_base}",
       ]
     }
   }
 
-  depends_on = [kubernetes_manifest.wait_for_istio_gateway]
+  depends_on = [data.kubernetes_resource.istio_gateway]
 }

--- a/main.tf
+++ b/main.tf
@@ -370,7 +370,16 @@ resource "argocd_application" "gateway" {
     delete = "15m"
   }
 
-  wait = var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? false : true
+  # Do not block on the application's health. The Gateway's HTTPS listener
+  # references the `istio-gateway-tls` Secret, which is created by cert-manager
+  # only after the Gateway is synced and its LoadBalancer IP is known (see the
+  # `kind` submodule). Waiting for "Healthy" here would deadlock: the app stays
+  # Degraded ("secret istio-gateway-tls not found") until the certificate is
+  # created, but the certificate depends on this module completing first.
+  # The Gateway still becomes Programmed and gets its IP at sync time, which is
+  # what downstream resources actually need; self-heal reconciles it to Healthy
+  # once the certificate Secret exists.
+  wait = false
 
   spec {
     project = var.argocd_project == null ? argocd_project.this[0].metadata.0.name : var.argocd_project


### PR DESCRIPTION
Summary
- Avoid Terraform and ArgoCD deadlock by setting wait=false on gateway application.
- Read ingress Service IP with data kubernetes_resource in kind module.
- Generate certificate SANs for subdomain plus base domain.

Validation
- terraform validate
- terraform -chdir=kind validate
- apply on kind created istio-gateway-tls and app reached Synced/Healthy.